### PR TITLE
Improve stars/forks padding

### DIFF
--- a/theme/default.css
+++ b/theme/default.css
@@ -178,10 +178,10 @@ body.ready {
 }
 .repo-card .status {
   font-size: 10px;
-  margin-right: 6px;
+  padding-right: 10px;
   text-transform: uppercase;
 }
 .repo-card .status strong {
   font-size: 12px;
-  margin-right: 1px;
+  padding-right: 5px;
 }


### PR DESCRIPTION
IMO, the pieces involved in the "N Forks N Stars" status text fall too close to each other, so I upped the padding a bit. I think it's an improvement, but let me know what you think!

Before:

![](https://cloudup.com/cp0a4SZRi6P+)

After:

![](https://cloudup.com/cL58kXWg0Z0+)
