### PR TITLE
Corrected 2 font names in default.css

### DIFF
--- a/theme/default.css
+++ b/theme/default.css
@@ -2,7 +2,7 @@ body {
   padding: 0;
   margin: 0;
   font-size: 14px;
-  font-family: "Helvetica Nenu", Hevetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   overflow: hidden;
 }
 body.ready {


### PR DESCRIPTION
Fixed two font names:
`"Helvetica Nenu"`  ->  `"Helvetica Neue"`
`Hevetica`  ->  `Helvetica`