### PR TITLE
fixed gc:base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Data parameters:
 You can also define in meta tags:
 
 ```html
-<meta name="gc:base" content="http://lab.lepture.com/github-cards/cards/">
+<meta name="gc:base" content="http://lab.lepture.com/github-cards/">
 <meta name="gc:theme" content="medium">
 <meta name="gc:client-id" content="client id string">
 <meta name="gc:client-secret" content="client secret string">


### PR DESCRIPTION
Hi, this card is so cool!

Then, I fixed target of `gc:base`, so `http://lab.lepture.com/github-cards/cards/` is not found now.