### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Example of user card:
 
 ```html
 <div class="github-card" data-user="lepture"></div>
-<script src="//cdn.jsdelivr.net/github-cards/latest/widget.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/lepture/github-cards@latest/jsdelivr/widget.js"></script>
 ```
 
 Example of repo card:
 
 ```html
 <div class="github-card" data-user="lepture" data-repo="github-cards"></div>
-<script src="//cdn.jsdelivr.net/github-cards/latest/widget.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/lepture/github-cards@latest/jsdelivr/widget.js"></script>
 ```
 
 Data parameters:
@@ -69,7 +69,7 @@ GitHub Cards is available on jsdelivr now. Use widget hosted on jsdelivr:
 
 ```html
 <div class="github-card" data-user="lepture" data-repo="github-cards"></div>
-<script src="https://cdn.jsdelivr.net/github-cards/latest/widget.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/lepture/github-cards@latest/jsdelivr/widget.js"></script>
 ```
 
 ## Contribution


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/lepture/github-cards.

Feel free to ping me if you have any questions regarding this change.