### PR TITLE
Use login if name is undefined

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -117,7 +117,7 @@ var qs = querystring();
         store(url, data);
       }
       data.login = user;
-      data.name = escape(data.name);
+      data.name = escape(data.name || user);
       data.public_repos = numberic(data.public_repos) || defaults;
       data.public_gists = numberic(data.public_gists) || defaults;
       data.followers = numberic(data.followers) || defaults;


### PR DESCRIPTION
This fixes an issue where the card will not render if
the user's name is not set. This will default to the
user's login instead of their name in case it isn't set.

Fixes https://github.com/lepture/github-cards/issues/44