### PR TITLE
Add iframe title for accessibliity

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -81,6 +81,7 @@
 
     var iframe = d.createElement('iframe');
     iframe.setAttribute('id', identity);
+    iframe.setAttribute('title', 'GitHub Profile');
     iframe.setAttribute('frameborder', 0);
     iframe.setAttribute('scrolling', 0);
     iframe.setAttribute('allowtransparency', true);


### PR DESCRIPTION
Currently, the `iframe` tag created by this library does not have a title. This causes issues for accessibility and in LightHouse audits. Here I've added a title which should resolve the issue.